### PR TITLE
Double Native Values

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/richardpiazza/Swift2D.git",
         "state": {
           "branch": null,
-          "revision": "d3aa067d4c9bfa97fb09b67b2b638bc134fae8d7",
-          "version": "1.1.0"
+          "revision": "4df6f74d3e3ad11075ea53fbb13fceda7c60b7b6",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.11.1"),
-        .package(url: "https://github.com/richardpiazza/Swift2D.git", from: "1.1.0"),
+        .package(url: "https://github.com/richardpiazza/Swift2D.git", from: "2.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftSVG/Circle.swift
+++ b/Sources/SwiftSVG/Circle.swift
@@ -13,25 +13,25 @@ import XMLCoder
 public struct Circle: Element {
     
     /// The x-axis coordinate of the center of the circle.
-    public var x: Float = 0.0
+    public var x: Double = 0.0
     /// The y-axis coordinate of the center of the circle.
-    public var y: Float = 0.0
+    public var y: Double = 0.0
     /// The radius of the circle.
-    public var r: Float = 0.0
+    public var r: Double = 0.0
     
     // CoreAttributes
     public var id: String?
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes
@@ -58,7 +58,7 @@ public struct Circle: Element {
     public init() {
     }
     
-    public init(x: Float, y: Float, r: Float) {
+    public init(x: Double, y: Double, r: Double) {
         self.x = x
         self.y = y
         self.r = r

--- a/Sources/SwiftSVG/Ellipse.swift
+++ b/Sources/SwiftSVG/Ellipse.swift
@@ -9,27 +9,27 @@ import XMLCoder
 public struct Ellipse: Element {
     
     /// The x position of the ellipse.
-    public var x: Float = 0.0
+    public var x: Double = 0.0
     /// The y position of the ellipse.
-    public var y: Float = 0.0
+    public var y: Double = 0.0
     /// The radius of the ellipse on the x axis.
-    public var rx: Float = 0.0
+    public var rx: Double = 0.0
     /// The radius of the ellipse on the y axis.
-    public var ry: Float = 0.0
+    public var ry: Double = 0.0
     
     // CoreAttributes
     public var id: String?
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes
@@ -57,7 +57,7 @@ public struct Ellipse: Element {
     public init() {
     }
     
-    public init(x: Float, y: Float, rx: Float, ry: Float) {
+    public init(x: Double, y: Double, rx: Double, ry: Double) {
         self.x = x
         self.y = y
         self.rx = rx

--- a/Sources/SwiftSVG/Fill.swift
+++ b/Sources/SwiftSVG/Fill.swift
@@ -3,7 +3,7 @@ import Swift2D
 public struct Fill {
     
     public var color: String?
-    public var opacity: Float?
+    public var opacity: Double?
     public var rule: Rule = .nonZero
     
     public init() {}

--- a/Sources/SwiftSVG/Group.swift
+++ b/Sources/SwiftSVG/Group.swift
@@ -26,14 +26,14 @@ public struct Group: Container, Element {
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes

--- a/Sources/SwiftSVG/Internal/EllipseProcessor.swift
+++ b/Sources/SwiftSVG/Internal/EllipseProcessor.swift
@@ -3,17 +3,17 @@ import Foundation
 
 struct EllipseProcessor {
     
-    let x: Float
-    let y: Float
-    let rx: Float
-    let ry: Float
+    let x: Double
+    let y: Double
+    let rx: Double
+    let ry: Double
     
     /// The _optimal_ offset for control points when representing a
     /// circle/ellipse as 4 bezier curves.
     ///
     /// [Stack Overflow](https://stackoverflow.com/questions/1734745/how-to-create-circle-with-bézier-curves)
-    static func controlPointOffset(_ radius: Float) -> Float {
-        return (Float(4.0/3.0) * tan(Float.pi / 8.0)) * radius
+    static func controlPointOffset(_ radius: Double) -> Double {
+        return (Double(4.0/3.0) * tan(Double.pi / 8.0)) * radius
     }
     
     init(ellipse: Ellipse) {

--- a/Sources/SwiftSVG/Internal/Path.Command+Internal.swift
+++ b/Sources/SwiftSVG/Internal/Path.Command+Internal.swift
@@ -64,7 +64,7 @@ extension Path.Command {
     /// - parameter value: The value to add to the existing value. If the current value equal `.isNaN`, than the
     ///                    supplied value is used as-is.
     /// - throws: `Path.Command.Error`
-    func adjustingArgument(at position: Int, by value: Float) throws -> Path.Command {
+    func adjustingArgument(at position: Int, by value: Double) throws -> Path.Command {
         switch self {
         case .moveTo(let point):
             switch position {

--- a/Sources/SwiftSVG/Internal/PathProcessor.swift
+++ b/Sources/SwiftSVG/Internal/PathProcessor.swift
@@ -16,7 +16,7 @@ class PathProcessor {
     private var currentPoint: Point = .zero
     /// The argument position of the _command to be processed.
     private var argumentPosition: Int = 0
-    /// Indicates that only a single `Float` will be processed on the next component pass.
+    /// Indicates that only a single `Double` will be processed on the next component pass.
     private var singleValue: Bool = false
     private var _commands: [Path.Command] = []
     
@@ -28,7 +28,7 @@ class PathProcessor {
     ///
     /// For each of the command components:
     /// * If a `Path.Command.Prefix` is identified: Setup a new `Command`.
-    /// * If a `Float` is identified: Continue a non-complete `Command`, or begin a new command using the last prefix.
+    /// * If a `Double` is identified: Continue a non-complete `Command`, or begin a new command using the last prefix.
     /// * Ascertain if the command is complete and update `pathOrigin`/`currentPoint`.
     func commands() throws -> [Path.Command] {
         _commands.removeAll()
@@ -44,8 +44,8 @@ class PathProcessor {
                 default:
                     try setupCommand(prefix: prefix)
                 }
-            } else if let _value = Float(component) {
-                let value = Float(_value)
+            } else if let _value = Double(component) {
+                let value = Double(_value)
                 if let command = _command {
                     try continueCommand(command, value: value)
                 } else {
@@ -185,7 +185,7 @@ class PathProcessor {
     }
     
     /// Process Value
-    private func continueCommand(_ command: Path.Command, value: Float) throws {
+    private func continueCommand(_ command: Path.Command, value: Double) throws {
         switch command {
         case .moveTo, .cubicBezierCurve, .quadraticBezierCurve, .ellipticalArcCurve:
             _command = try command.adjustingArgument(at: argumentPosition, by: value)
@@ -231,7 +231,7 @@ class PathProcessor {
     }
     
     /// New Command (using the last prefix)
-    private func setupNextCommand(value: Float) throws {
+    private func setupNextCommand(value: Double) throws {
         guard let command = _commands.last else {
             throw Path.Command.Error.invalidRelativeCommand
         }

--- a/Sources/SwiftSVG/Internal/Point+SwiftSVG.swift
+++ b/Sources/SwiftSVG/Internal/Point+SwiftSVG.swift
@@ -2,7 +2,7 @@ import Swift2D
 
 extension Point {
     static var nan: Point {
-        return Point(x: Float.nan, y: Float.nan)
+        return Point(x: Double.nan, y: Double.nan)
     }
     
     var hasNaN: Bool {
@@ -10,12 +10,12 @@ extension Point {
     }
     
     /// Returns a copy of the instance with the **x** value replaced with the provided value.
-    func with(x value: Float) -> Point {
+    func with(x value: Double) -> Point {
         return Point(x: value, y: y)
     }
     
     /// Returns a copy of the instance with the **y** value replaced with the provided value.
-    func with(y value: Float) -> Point {
+    func with(y value: Double) -> Point {
         return Point(x: x, y: value)
     }
     
@@ -23,7 +23,7 @@ extension Point {
     ///
     /// This will explicitly check for `.isNaN`, and if encountered, will simply
     /// use the provided value.
-    func adjusting(x value: Float) -> Point {
+    func adjusting(x value: Double) -> Point {
         return (x.isNaN) ? with(x: value) : with(x: x + value)
     }
     
@@ -31,7 +31,7 @@ extension Point {
     ///
     /// This will explicitly check for `.isNaN`, and if encountered, will simply
     /// use the provided value.
-    func adjusting(y value: Float) -> Point {
+    func adjusting(y value: Double) -> Point {
         return (y.isNaN) ? with(y: value) : with(y: y + value)
     }
 }

--- a/Sources/SwiftSVG/Internal/PolygonProcressor.swift
+++ b/Sources/SwiftSVG/Internal/PolygonProcressor.swift
@@ -24,11 +24,11 @@ struct PolygonProcessor {
         
         var firstValue: Bool = true
         for (idx, component) in components.enumerated() {
-            guard let _value = Float(component) else {
+            guard let _value = Double(component) else {
                 return commands
             }
             
-            let value = Float(_value)
+            let value = Double(_value)
             
             if firstValue {
                 if idx == 0 {

--- a/Sources/SwiftSVG/Internal/PolylineProcessor.swift
+++ b/Sources/SwiftSVG/Internal/PolylineProcessor.swift
@@ -11,7 +11,7 @@ struct PolylineProcessor {
     func commands() throws -> [Path.Command] {
         let pairs = points.components(separatedBy: " ")
         let components = pairs.flatMap({ $0.components(separatedBy: ",") })
-        let values = components.compactMap({ Float($0) }).map({ Float($0) })
+        let values = components.compactMap({ Double($0) }).map({ Double($0) })
         
         guard values.count > 2 else {
             // More than just a starting point is required.
@@ -30,7 +30,7 @@ struct PolylineProcessor {
         
         commands.append(.moveTo(point: Point(x: move[0], y: move[1])))
         
-        var _value: Float = .nan
+        var _value: Double = .nan
         segments.forEach { (value) in
             if _value.isNaN {
                 _value = value

--- a/Sources/SwiftSVG/Line.swift
+++ b/Sources/SwiftSVG/Line.swift
@@ -9,27 +9,27 @@ import XMLCoder
 public struct Line: Element {
     
     /// Defines the x-axis coordinate of the line starting point.
-    public var x1: Float = 0.0
+    public var x1: Double = 0.0
     /// Defines the x-axis coordinate of the line ending point.
-    public var y1: Float = 0.0
+    public var y1: Double = 0.0
     /// Defines the y-axis coordinate of the line starting point.
-    public var x2: Float = 0.0
+    public var x2: Double = 0.0
     /// Defines the y-axis coordinate of the line ending point.
-    public var y2: Float = 0.0
+    public var y2: Double = 0.0
     
     // CoreAttributes
     public var id: String?
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes
@@ -57,7 +57,7 @@ public struct Line: Element {
     public init() {
     }
     
-    public init(x1: Float, y1: Float, x2: Float, y2: Float) {
+    public init(x1: Double, y1: Double, x2: Double, y2: Double) {
         self.x1 = x1
         self.y1 = y1
         self.x2 = x2

--- a/Sources/SwiftSVG/Path.Command.swift
+++ b/Sources/SwiftSVG/Path.Command.swift
@@ -15,7 +15,7 @@ public extension Path {
         /// Draw a smooth curve using two points (+ origin)
         case quadraticBezierCurve(cp: Point, point: Point)
         /// Draw a curve defined as a portion of an ellipse
-        case ellipticalArcCurve(rx: Float, ry: Float, angle: Float, largeArc: Bool, clockwise: Bool, point: Point)
+        case ellipticalArcCurve(rx: Double, ry: Double, angle: Double, largeArc: Bool, clockwise: Bool, point: Point)
         /// ClosePath instructions draw a straight line from the current position to the first point in the path.
         case closePath
         

--- a/Sources/SwiftSVG/Path.swift
+++ b/Sources/SwiftSVG/Path.swift
@@ -19,14 +19,14 @@ public struct Path: Element {
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes

--- a/Sources/SwiftSVG/Polygon.swift
+++ b/Sources/SwiftSVG/Polygon.swift
@@ -18,14 +18,14 @@ public struct Polygon: Element {
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes

--- a/Sources/SwiftSVG/Polyline.swift
+++ b/Sources/SwiftSVG/Polyline.swift
@@ -17,14 +17,14 @@ public struct Polyline: Element {
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes

--- a/Sources/SwiftSVG/PresentationAttributes.swift
+++ b/Sources/SwiftSVG/PresentationAttributes.swift
@@ -2,14 +2,14 @@ import Swift2D
 
 public protocol PresentationAttributes {
     var fillColor: String? { get set }
-    var fillOpacity: Float? { get set }
+    var fillOpacity: Double? { get set }
     var fillRule: Fill.Rule? { get set }
     var strokeColor: String? { get set }
-    var strokeWidth: Float? { get set }
-    var strokeOpacity: Float? { get set }
+    var strokeWidth: Double? { get set }
+    var strokeOpacity: Double? { get set }
     var strokeLineCap: Stroke.LineCap? { get set }
     var strokeLineJoin: Stroke.LineJoin? { get set }
-    var strokeMiterLimit: Float? { get set }
+    var strokeMiterLimit: Double? { get set }
     var transform: String? { get set }
 }
 

--- a/Sources/SwiftSVG/Rectangle.swift
+++ b/Sources/SwiftSVG/Rectangle.swift
@@ -13,34 +13,34 @@ public struct Rectangle: Element {
     
     /// The x-axis coordinate of the side of the rectangle which
     /// has the smaller x-axis coordinate value.
-    public var x: Float = 0.0
+    public var x: Double = 0.0
     /// The y-axis coordinate of the side of the rectangle which
     /// has the smaller y-axis coordinate value
-    public var y: Float = 0.0
+    public var y: Double = 0.0
     /// The width of the rectangle.
-    public var width: Float = 0.0
+    public var width: Double = 0.0
     /// The height of the rectangle.
-    public var height: Float = 0.0
+    public var height: Double = 0.0
     /// For rounded rectangles, the x-axis radius of the ellipse used
     /// to round off the corners of the rectangle.
-    public var rx: Float?
+    public var rx: Double?
     /// For rounded rectangles, the y-axis radius of the ellipse used
     /// to round off the corners of the rectangle.
-    public var ry: Float?
+    public var ry: Double?
     
     // CoreAttributes
     public var id: String?
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes
@@ -70,7 +70,7 @@ public struct Rectangle: Element {
     public init() {
     }
     
-    public init(x: Float, y: Float, width: Float, height: Float, rx: Float? = nil, ry: Float? = nil) {
+    public init(x: Double, y: Double, width: Double, height: Double, rx: Double? = nil, ry: Double? = nil) {
         self.x = x
         self.y = y
         self.width = width

--- a/Sources/SwiftSVG/SVG+Swift2D.swift
+++ b/Sources/SwiftSVG/SVG+Swift2D.swift
@@ -12,7 +12,7 @@ public extension SVG {
     ///
     /// All paths created by this framework are outputted in a 'square'.
     var outputSize: Size {
-        let size = originalSize
+        let size = (pixelSize ?? viewBoxSize) ?? .zero
         let maxDimension = max(size.width, size.height)
         return Size(width: maxDimension, height: maxDimension)
     }
@@ -28,11 +28,11 @@ public extension SVG {
             return nil
         }
         
-        guard let width = Int(components[2]) else {
+        guard let width = Double(components[2]) else {
             return nil
         }
         
-        guard let height = Int(components[3]) else {
+        guard let height = Double(components[3]) else {
             return nil
         }
         
@@ -52,7 +52,7 @@ public extension SVG {
         let widthRawValue = width.replacingOccurrences(of: "px", with: "", options: .caseInsensitive, range: nil)
         let heightRawValue = height.replacingOccurrences(of: "px", with: "", options: .caseInsensitive, range: nil)
         
-        guard let w = Int(widthRawValue), let h = Int(heightRawValue) else {
+        guard let w = Double(widthRawValue), let h = Double(heightRawValue) else {
             return nil
         }
         

--- a/Sources/SwiftSVG/Stroke.swift
+++ b/Sources/SwiftSVG/Stroke.swift
@@ -3,11 +3,11 @@ import Swift2D
 public struct Stroke {
     
     public var color: String?
-    public var width: Float?
-    public var opacity: Float?
+    public var width: Double?
+    public var opacity: Double?
     public var lineCap: LineCap  = .butt
     public var lineJoin: LineJoin = .miter
-    public var miterLimit: Float?
+    public var miterLimit: Double?
     
     public init() {
         

--- a/Sources/SwiftSVG/Text.swift
+++ b/Sources/SwiftSVG/Text.swift
@@ -10,24 +10,24 @@ import XMLCoder
 public struct Text: Element {
     
     public var value: String = ""
-    public var x: Float?
-    public var y: Float?
-    public var dx: Float?
-    public var dy: Float?
+    public var x: Double?
+    public var y: Double?
+    public var dx: Double?
+    public var dy: Double?
     
     // CoreAttributes
     public var id: String?
     
     // PresentationAttributes
     public var fillColor: String?
-    public var fillOpacity: Float?
+    public var fillOpacity: Double?
     public var fillRule: Fill.Rule?
     public var strokeColor: String?
-    public var strokeWidth: Float?
-    public var strokeOpacity: Float?
+    public var strokeWidth: Double?
+    public var strokeOpacity: Double?
     public var strokeLineCap: Stroke.LineCap?
     public var strokeLineJoin: Stroke.LineJoin?
-    public var strokeMiterLimit: Float?
+    public var strokeMiterLimit: Double?
     public var transform: String?
     
     // StylingAttributes

--- a/Sources/SwiftSVG/Transformation.swift
+++ b/Sources/SwiftSVG/Transformation.swift
@@ -32,9 +32,9 @@ import Swift2D
 /// | [W3](https://www.w3.org/TR/SVG11/coords.html#TransformAttribute)
 public enum Transformation {
     /// Moves an object by x & y. (Y is assumed to be '0' if not provided)
-    case translate(x: Float, y: Float)
+    case translate(x: Double, y: Double)
     /// Specifies a transformation in the form of a transformation matrix of six values.
-    case matrix(a: Float, b: Float, c: Float, d: Float, e: Float, f: Float)
+    case matrix(a: Double, b: Double, c: Double, d: Double, e: Double, f: Double)
     
     public enum Prefix: String, CaseIterable {
         case translate
@@ -64,7 +64,7 @@ public enum Transformation {
             var components = substring.split(separator: " ", omittingEmptySubsequences: true).map({ String($0) })
             components = components.flatMap({ $0.components(separatedBy: ",") })
             
-            let values = components.compactMap({ Float($0) }).map({ Float($0) })
+            let values = components.compactMap({ Double($0) }).map({ Double($0) })
             guard values.count > 0 else {
                 return nil
             }
@@ -90,7 +90,7 @@ public enum Transformation {
             var components = substring.split(separator: " ", omittingEmptySubsequences: true).map({ String($0) })
             components = components.flatMap({ $0.components(separatedBy: ",") })
             
-            let values = components.compactMap({ Float($0) }).map({ Float($0) })
+            let values = components.compactMap({ Double($0) }).map({ Double($0) })
             guard values.count > 5 else {
                 return nil
             }

--- a/Tests/SwiftSVGTests/CommandRepresentableTests.swift
+++ b/Tests/SwiftSVGTests/CommandRepresentableTests.swift
@@ -45,8 +45,8 @@ final class CommandRepresentableTests: XCTestCase {
     }
     
     func testEllipse() throws {
-        let x: Float = 50.0
-        let y: Float = 25.0
+        let x: Double = 50.0
+        let y: Double = 25.0
         
         let ellipse = Ellipse(x: x, y: y, rx: 50, ry: 25)
         let xOffset = EllipseProcessor.controlPointOffset(ellipse.rx)

--- a/Tests/SwiftSVGTests/Extensions.swift
+++ b/Tests/SwiftSVGTests/Extensions.swift
@@ -83,8 +83,8 @@ extension Path.Command: RoughEquatability {
     }
 }
 
-extension Float: RoughEquatability {
-    public static func ~~ (lhs: Float, rhs: Float) -> Bool {
+extension Double: RoughEquatability {
+    public static func ~~ (lhs: Double, rhs: Double) -> Bool {
         // Float.abs is not available on some platforms.
         return Swift.abs(lhs - rhs) < 0.001
     }


### PR DESCRIPTION
Replaces all instances of `Float` with `Double`. This matches the Swift native floating-point type and changes made to `Swift2D`. Swift 5.5 will also offer native interchangeability between `Double` and `CGFloat` (SE-0307)