### PR TITLE
Make Stroke and Fill properties non-null.

### DIFF
--- a/Sources/SwiftSVG/Fill.swift
+++ b/Sources/SwiftSVG/Fill.swift
@@ -2,11 +2,15 @@ import Swift2D
 
 public struct Fill {
     
-    public var color: String?
-    public var opacity: Double?
+    public var color: String
+    public var opacity: Double
     public var rule: Rule = .nonZero
     
-    public init() {}
+    public init(color: String?, opacity: Double?, rule: Rule?) {
+        self.color = color ?? "black"
+        self.opacity = opacity ?? 1
+        self.rule = rule ?? .nonZero
+    }
     
     /// Presentation attribute defining the algorithm to use to determine the inside part of a shape.
     ///

--- a/Sources/SwiftSVG/Fill.swift
+++ b/Sources/SwiftSVG/Fill.swift
@@ -11,6 +11,12 @@ public struct Fill {
         self.opacity = opacity ?? 1
         self.rule = rule ?? .nonZero
     }
+
+    public init() {
+        self.init(color: nil,
+                  opacity: nil,
+                  rule: nil)
+    }
     
     /// Presentation attribute defining the algorithm to use to determine the inside part of a shape.
     ///

--- a/Sources/SwiftSVG/Fill.swift
+++ b/Sources/SwiftSVG/Fill.swift
@@ -1,15 +1,28 @@
 import Swift2D
 
 public struct Fill {
-    
+    public struct Default {
+        public static let color = "black"
+        public static let opacity = 1.0
+        public static let rule = Rule.nonZero
+    }
+
     public var color: String
     public var opacity: Double
-    public var rule: Rule = .nonZero
-    
+    public var rule: Rule
+
+    /// Initialize aggregate data related to a `Fill`.
+    ///
+    /// Any supplied `nil` values are replaced with the corresponding value from `Fill.Default`
+    ///
+    /// - parameters:
+    ///   - color: Name of or hexadecimal value used to color the fill.
+    ///   - opacity: The level of opaqueness given applied to the color.
+    ///   - rule: Algorithm used to determine the inside of the shape.
     public init(color: String?, opacity: Double?, rule: Rule?) {
-        self.color = color ?? "black"
-        self.opacity = opacity ?? 1
-        self.rule = rule ?? .nonZero
+        self.color = color ?? Fill.Default.color
+        self.opacity = opacity ?? Fill.Default.opacity
+        self.rule = rule ?? Fill.Default.rule
     }
 
     public init() {
@@ -17,7 +30,7 @@ public struct Fill {
                   opacity: nil,
                   rule: nil)
     }
-    
+
     /// Presentation attribute defining the algorithm to use to determine the inside part of a shape.
     ///
     /// The default `Rule` is `.nonzero`.

--- a/Sources/SwiftSVG/PresentationAttributes.swift
+++ b/Sources/SwiftSVG/PresentationAttributes.swift
@@ -80,10 +80,9 @@ public extension PresentationAttributes {
                 return nil
             }
             
-            var fill = Fill()
-            fill.color = fillColor ?? "black"
-            fill.opacity = fillOpacity ?? 1.0
-            return fill
+            return Fill(color: fillColor,
+                        opacity: fillOpacity,
+                        rule: fillRule)
         }
         set {
             fillColor = newValue?.color
@@ -98,14 +97,12 @@ public extension PresentationAttributes {
                 return nil
             }
             
-            var stroke = Stroke()
-            stroke.color = strokeColor ?? "black"
-            stroke.opacity = strokeOpacity ?? 1.0
-            stroke.width = strokeWidth ?? 1.0
-            stroke.lineCap = strokeLineCap ?? .butt
-            stroke.lineJoin = strokeLineJoin ?? .miter
-            stroke.miterLimit = strokeMiterLimit
-            return stroke
+            return Stroke(color: strokeColor,
+                          width: strokeWidth,
+                          opacity: strokeOpacity,
+                          lineCap: strokeLineCap,
+                          lineJoin: strokeLineJoin,
+                          miterLimit: strokeMiterLimit)
         }
         set {
             strokeColor = newValue?.color

--- a/Sources/SwiftSVG/Stroke.swift
+++ b/Sources/SwiftSVG/Stroke.swift
@@ -2,15 +2,20 @@ import Swift2D
 
 public struct Stroke {
     
-    public var color: String?
-    public var width: Double?
-    public var opacity: Double?
+    public var color: String
+    public var width: Double
+    public var opacity: Double
     public var lineCap: LineCap  = .butt
     public var lineJoin: LineJoin = .miter
-    public var miterLimit: Double?
+    public var miterLimit: Double
     
-    public init() {
-        
+    public init(color: String?, width: Double?, opacity: Double?, lineCap: LineCap?, lineJoin: LineJoin?, miterLimit: Double?) {
+        self.color = color ?? "black"
+        self.width = width ?? 1
+        self.opacity = opacity ?? 1
+        self.lineCap = lineCap ?? .butt
+        self.lineJoin = lineJoin ?? .miter
+        self.miterLimit = miterLimit ?? 4
     }
     
     /// Presentation attribute defining the shape to be used at the end of open subpaths when they are stroked.

--- a/Sources/SwiftSVG/Stroke.swift
+++ b/Sources/SwiftSVG/Stroke.swift
@@ -17,6 +17,15 @@ public struct Stroke {
         self.lineJoin = lineJoin ?? .miter
         self.miterLimit = miterLimit ?? 4
     }
+
+    public init() {
+        self.init(color: nil,
+                  width: nil,
+                  opacity: nil,
+                  lineCap: nil,
+                  lineJoin: nil,
+                  miterLimit: nil)
+    }
     
     /// Presentation attribute defining the shape to be used at the end of open subpaths when they are stroked.
     ///

--- a/Sources/SwiftSVG/Stroke.swift
+++ b/Sources/SwiftSVG/Stroke.swift
@@ -1,21 +1,41 @@
 import Swift2D
 
 public struct Stroke {
-    
+    public struct Default {
+        public static let color = "none"
+        public static let width = 1.0
+        public static let opacity = 1.0
+        public static let lineCap = LineCap.butt
+        public static let lineJoin = LineJoin.miter
+        public static let miterLimit = 4.0
+    }
+
     public var color: String
     public var width: Double
     public var opacity: Double
-    public var lineCap: LineCap  = .butt
-    public var lineJoin: LineJoin = .miter
+    public var lineCap: LineCap
+    public var lineJoin: LineJoin
     public var miterLimit: Double
     
+    /// Initialize aggregate data related to a `Stroke`.
+    ///
+    /// Any supplied `nil` values are replaced with the corresponding value from `Stroke.Default`
+    ///
+    /// - parameters:
+    ///   - color: Name of or hexadecimal value used to color the stroke.
+    ///   - width: The width of the stroekd line.
+    ///   - opacity: The level of opaqueness given applied to the color.
+    ///   - rule: Algorithm used to determine the inside of the shape.
+    ///   - lineCap: The styling of the endpoints of the stroke.
+    ///   - lineJoin: The styling of the joining points of the stroke.
+    ///   - miterLimit: Threshold for controlling the length of the miter.
     public init(color: String?, width: Double?, opacity: Double?, lineCap: LineCap?, lineJoin: LineJoin?, miterLimit: Double?) {
-        self.color = color ?? "black"
-        self.width = width ?? 1
-        self.opacity = opacity ?? 1
-        self.lineCap = lineCap ?? .butt
-        self.lineJoin = lineJoin ?? .miter
-        self.miterLimit = miterLimit ?? 4
+        self.color = color ?? Stroke.Default.color
+        self.width = width ?? Stroke.Default.width
+        self.opacity = opacity ?? Stroke.Default.opacity
+        self.lineCap = lineCap ?? Stroke.Default.lineCap
+        self.lineJoin = lineJoin ?? Stroke.Default.lineJoin
+        self.miterLimit = miterLimit ?? Stroke.Default.miterLimit
     }
 
     public init() {


### PR DESCRIPTION
As the Stroke's and Fill's properties are already always non-null I defined them as such in the struct itself to prevent needless unwrapping when using the structs.
This also has the advantage that any default values are always enforced at a single point in code.