### PR TITLE
Ellipse Parameter Syntax Error

### DIFF
--- a/Sources/SwiftSVG/Ellipse.swift
+++ b/Sources/SwiftSVG/Ellipse.swift
@@ -66,7 +66,7 @@ public struct Ellipse: Element {
     
     // MARK: - CustomStringConvertible
     public var description: String {
-        let desc = "<ellipse cx=\"\(x)\" cy=\"\(y)\" rx=\"\(rx)\", ry=\"\(ry)\""
+        let desc = "<ellipse cx=\"\(x)\" cy=\"\(y)\" rx=\"\(rx)\" ry=\"\(ry)\""
         return desc + " \(attributeDescription) />"
     }
 }


### PR DESCRIPTION
Redundant Comma in Attribute Definition

There appears to be a syntax error in the SVG ellipse parameters. Specifically, a redundant comma is present in the attribute definition, leading to potential parsing issues or unexpected behavior. The issue occurs in the ellipse element's attribute string: `<ellipse cx=\"\(x)\" cy=\"\(y)\" rx=\"\(rx)\", ry=\"\(ry)\"`. The comma between `rx` and `ry` attributes is not required and should be removed to adhere to proper SVG syntax.