### PR TITLE
Enhance SVG Accessibility with 'title' and 'desc' in Groups

### DIFF
--- a/Sources/SwiftSVG/Ellipse.swift
+++ b/Sources/SwiftSVG/Ellipse.swift
@@ -66,7 +66,7 @@ public struct Ellipse: Element {
     
     // MARK: - CustomStringConvertible
     public var description: String {
-        let desc = "<ellipse cx=\"\(x)\" cy=\"\(y)\" rx=\"\(rx)\", ry=\"\(ry)\""
+        let desc = "<ellipse cx=\"\(x)\" cy=\"\(y)\" rx=\"\(rx)\" ry=\"\(ry)\""
         return desc + " \(attributeDescription) />"
     }
 }

--- a/Sources/SwiftSVG/Group.swift
+++ b/Sources/SwiftSVG/Group.swift
@@ -23,7 +23,9 @@ public struct Group: Container, Element {
     
     // CoreAttributes
     public var id: String?
-    
+    public var title: String?
+    public var desc: String?
+
     // PresentationAttributes
     public var fillColor: String?
     public var fillOpacity: Double?
@@ -50,6 +52,8 @@ public struct Group: Container, Element {
         case rectangles = "rect"
         case texts = "text"
         case id
+        case title
+        case desc
         case fillColor = "fill"
         case fillOpacity = "fill-opacity"
         case fillRule = "fill-rule"
@@ -68,7 +72,19 @@ public struct Group: Container, Element {
     
     // MARK: - CustomStringConvertible
     public var description: String {
-        return "<g \(attributeDescription) >\(containerDescription)\n</g>"
+        var contents: String = ""
+
+        if let title = self.title {
+            contents.append("\n<title>\(title)</title>")
+        }
+
+        if let desc = self.desc {
+            contents.append("\n<desc>\(desc)</desc>")
+        }
+
+        contents.append(containerDescription)
+
+        return "<g \(attributeDescription) >\(contents)\n</g>"
     }
 }
 


### PR DESCRIPTION
Currently, the SVG elements lack semantic details that could improve accessibility and provide a richer context for users relying on screen readers and other assistive technologies. To address this, I propose adding `title` and `desc` elements to our SVG groups (<g> tags). These elements will provide textual descriptions of the graphics, enhancing the understanding of the SVG content's structure and semantics.
```
<g>
    <title>Group Title</title>
    <desc>Description of the elements within the group and their interrelation.</desc>
    <!-- SVG Elements here... -->
</g>
```
By implementing these changes, we can improve the SVGs' accessibility, making our content more inclusive and compliant with web accessibility standards. This enhancement is not only in alignment with SVG best practices but also reinforces our commitment to creating accessible content for all users.